### PR TITLE
Disable webview

### DIFF
--- a/wxc/CMakeLists.txt
+++ b/wxc/CMakeLists.txt
@@ -158,7 +158,7 @@ set_property(TARGET wxc PROPERTY
     CXX_STANDARD 14
     CXX_STANDARD_REQUIRED ON)
 
-find_package(wxWidgets REQUIRED gl base core richtext stc webview xrc
+find_package(wxWidgets REQUIRED gl base core richtext stc xrc
     propgrid qa html adv aui ribbon net)
 
 if(wxWidgets_FOUND)

--- a/wxc/package.nix
+++ b/wxc/package.nix
@@ -22,9 +22,4 @@ stdenv.mkDerivation {
   buildInputs = [
     libGL
   ];
-
-  # We shouldn't set this, but FindwxWidgets fails to properly fill it and
-  # configuration fails with
-  # "Could NOT find wxWidgets (missing: wxWidgets_LIBRARIES)"
-  cmakeFlags = [ "-DwxWidgets_LIBRARIES=-L${wxGTK32}/lib" ];
 }


### PR DESCRIPTION
We don't actually use it, and the default wxGTK nix package doesn't provide it, so this commit fixes the nix shell too. If we want to enable it again, we have to override wxGTK and set withWebKit = true

---

I can run the examples now \o/